### PR TITLE
Enabling readable stream

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "json-csv",
-  "version": "0.0.8",
+  "version": "0.1.0",
   "description": "Export a richly structured, JSON array to CSV",
   "homepage": "https://github.com/IWSLLC/json-csv",
-  "author": "Nathan Bridgewater <nathan@integratedwebsystems.com> (http://integratedwebsystems.com/)",
+  "author": "Nathan Bridgewater <nathan@iws.io> (http://iws.io/)",
   "keywords": [
     "csv",
     "export",


### PR DESCRIPTION
I used this for a project where I needed export a huge about of data to CSV. The buffered code from before caused the process to run out of memory. Now presenting: readable. I'm kind of a n00b with JS Node streams, but this is the first round.  Post issues if anything comes up! 

```
//pipe to console
jsoncsv.createReadStream({data : [...], fields : [...]}).pipe(process.stdout)
```

pipe to file

```
var fs = require("fs")
var writable_file = fs.createWriteStream("output.csv", {encoding : 'utf8'})
jsoncsv.createReadStream({data : [...], fields : [...]}).pipe(writable_file)
```

You can also use the standard readable stream events like: 'end', 'readable' to detect the end of the stream or read it yourself. 

```
var reader = jsoncsv.createReadStream({data : [...], fields : [...]})
reader.on('end', function() { /* triggers when the reader has nothing left to read; when done*/ })
reader.pipe(process.stdout) // go ahead and pipe it somewhere
```
