### PR TITLE
in the case that the data object is undefined/null

### DIFF
--- a/exporter.js
+++ b/exporter.js
@@ -94,6 +94,9 @@ exporter.prototype.getValue = function(data, arg) {
 }
 
 exporter.prototype.getValueIx = function(data, args, ix) {
+  if (!data)
+    return ''
+  
   var val = data[args[ix]]
   if (typeof val === 'undefined')
     return ''


### PR DESCRIPTION
When doing exports on flexible-schema data, it's possible that some part of the data will not be there.

This should spit out an empty value in the case of this.