### PR TITLE
Adding  keyword to support multi-field filters.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
-- '5.0'
-- '4.2'
+- '5'
+- '4'
 - '0.10'
 script: "mocha"
 cache:

--- a/exporter.js
+++ b/exporter.js
@@ -48,16 +48,16 @@ exporter.prototype.prepValue = function(arg, forceQuoted) {
 
 exporter.prototype.getHeaderRow = function() {
   var self = this
-  var header = _.reduce(this.options.fields, function(line, field) {
+  var header = _.reduce(self.options.fields, function(line, field) {
     var label = field.label || field.field
     if (line === 'START') {
       line = '';
     } else {
-      line += this.fieldSeparator
+      line += self.fieldSeparator
     }
     line += self.prepValue(label)
     return line
-  }, 'START', this)
+  }, 'START')
   header += '\r\n'
   return header
 }
@@ -68,7 +68,7 @@ exporter.prototype.getBodyRow = function(data) {
     if (line === 'START') {
       line = '';
     } else {
-      line += this.fieldSeparator
+      line += self.fieldSeparator
     }
     var val = self.getValue(data, field.name)
     if (field.filter) {
@@ -79,7 +79,7 @@ exporter.prototype.getBodyRow = function(data) {
       line += self.prepValue(val.toString(), quoted)
     }
     return line
-  }, 'START', this)
+  }, 'START', self)
 
   row += '\r\n'
   return row
@@ -89,17 +89,23 @@ exporter.prototype.getValue = function(data, arg) {
   var args = arg.split('.')
   if (args.length > 0)
     return this.getValueIx(data, args, 0)
-  return data[args[0]];
+  return ""
 }
 
 exporter.prototype.getValueIx = function(data, args, ix) {
   if (!data)
     return ''
 
+  //for filtered fields using the whole row as a source.
+  //`this` is a keyword here; hoping not to conflict with existing fields.
+  if (args[0] === "this")
+    return data
+
   var val = data[args[ix]]
   if (typeof val === 'undefined')
     return ''
 
+  //walk the dot-notation recursively to get the remaining values.
   if ((args.length-1) > ix)
     return this.getValueIx(val, args, ix+1);
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "json-csv",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Export a richly structured, JSON array to CSV",
   "homepage": "https://github.com/IWSLLC/json-csv",
   "author": "Nathan Bridgewater <info@iws.io> (http://iws.io/)",
@@ -19,8 +19,8 @@
   },
   "devDependencies": {
     "coffee-script": "^1.10.0",
-    "mocha": "^2.3.3",
-    "should": "^7.1.1"
+    "mocha": "^2.4.5",
+    "should": "^8.3.0"
   },
   "bugs": {
     "url": "https://github.com/IWSLLC/json-csv/issues"
@@ -31,7 +31,7 @@
   "dependencies": {
     "concat-stream": "^1.5.1",
     "event-stream": "^3.3.2",
-    "lodash": "^3.10.1"
+    "lodash": "^4.7.0"
   },
   "scripts": {
     "test": "mocha"

--- a/test/issue-21.coffee
+++ b/test/issue-21.coffee
@@ -1,0 +1,21 @@
+jsoncsv = require '../index'
+should = require "should"
+
+describe "Issue 21", ->
+  describe "When exporting a column, concatenated from two source fields", ->
+    before (done) ->
+      @items = [{a: "first", b: "second"}, {a: "third", b:"fourth"}, {a: "fifth", b: "sixth"}]
+      jsoncsv.csvBuffered @items, {
+        fields: [
+          {
+            name: "this"
+            label: 'c'
+            filter: (v) ->
+              return "#{v?.a}#{v?.b}"
+          }
+        ]}, (err, csv) =>
+          @csv = csv
+          @err = err
+        done()
+
+    it "should export concatenated a and b", -> @csv.should.equal "c\r\nfirstsecond\r\nthirdfourth\r\nfifthsixth\r\n"


### PR DESCRIPTION
Resolves #21 

Now when using the field name keyword `"this"`, it will pass the entire source row to the `filter` function to be consumed and reduced. Please return a string

```javascript
var items = [
  {
    a: "first",
    b: "second"
  }, {
    a: "third",
    b: "fourth"
  }, {
    a: "fifth",
    b: "sixth"
  }
];

//this field setup will return a concatenated a + b as a single column (labeled 'c') in the CSV. 
  var fields = [
    {
      name: "this",
      label: 'c',
      filter: function(v) {
        return "" + v.a + v.b;
      }
    }
  ]
```