### PR TITLE
Added support to OR || operator in column names to allow multiples alternatives...

### DIFF
--- a/exporter.js
+++ b/exporter.js
@@ -72,6 +72,24 @@ exporter.prototype.getBodyRow = function(data) {
       line += self.fieldSeparator
     }
     var val = self.getValue(data, field.name)
+    // vinicioslc support to OR || operator  allowing multiples names to the same column
+    // the code will use the last non null and non empty value
+    if (field.name.includes('||')) {
+      // by default column is empty
+      val = ''
+      let fields = field.name.split('||');
+      // for each alternative
+      fields.forEach(field => {
+        // get value and associate
+        let fieldVal = self.getValue(data, field)
+        // remove whitespaces and check if non null before assign
+        if (typeof val !== 'undefined' && val !== null && fieldVal.trim().length > 0 && fieldVal.trim() != "") {
+          val = fieldVal
+        }
+        //do this for every field
+      });
+    }
+
     if (field.filter) {
       val = field.filter(val)
     }

--- a/test/or-operator.coffee
+++ b/test/or-operator.coffee
@@ -1,0 +1,35 @@
+jsoncsv = require '../index'
+should = require "should"
+
+describe "OR || operator", ->
+	it "should merge column1, 2 or 3 into combinedCol (from 2 to single column two entries)", (done) ->
+		arrayItems = [ 
+			{ column1 : 'foo1'},
+				{ column2 : 'foo2'} ]; #--> all 2 columns should be merged one column 'combinedCol'
+
+		jsoncsv.csvBuffered arrayItems, { fields: [ { name : 'column1||column2', label : 'combinedCol' } ] }, (err,csv)->
+			csv.should.equal 'combinedCol\r\nfoo1\r\nfoo2\r\n'
+			done()
+
+	it "should use column1, 2 or 3 into combinedCol (from 3 to single columns 3 entries)", (done) ->
+		arrayItems = [ 
+			{ column1 : 'foo1'},
+				{ column2 : 'foo2'},
+					{ column3 : 'foo3'} ]; #--> all 3 columns should be merged one column 'combinedCol'
+
+		jsoncsv.csvBuffered arrayItems, { fields: [ { name : 'column1||column2||column3', label : 'combinedCol' } ] }, (err,csv)->
+			csv.should.equal 'combinedCol\r\nfoo1\r\nfoo2\r\nfoo3\r\n'
+			done()
+
+	it "should merge column1, 2 or 3 into combinedCol and then parse others (from 3 to single column with other columns)", (done) ->
+		arrayItems = [ 
+			{ column1 : 'foo1', otherData: 'baz1'},
+				{ column1 : 'fooIgnored', column2 : 'foo2', otherData: 'baz2'},
+					{ column3 : 'foo3', otherData: 'baz3', anotherData: 'daz3'} ]; #--> should merge column1, 2 and 3 and parse others normally 'combinedCol'
+
+		jsoncsv.csvBuffered arrayItems, { fields: [ 
+			{ name : 'column1||column2||column3', label : 'combinedCol' },
+				{ name : 'otherData', label : 'otherColumn' },
+					{ name : 'anotherData', label : 'anotherColumn' } ], fieldSeparator : ';'}, (err,csv)->
+			csv.should.equal 'combinedCol;otherColumn;anotherColumn\r\nfoo1;baz1;\r\nfoo2;baz2;\r\nfoo3;baz3;daz3\r\n'
+			done()


### PR DESCRIPTION
I have added support to "||" OR operator allowing multiples column options mapped to the new json one, code will use the last non null, and non empty value, otherwise will be empty value.

Example Usage : 
"COLUMN1||COLUMN2" 

It will search value in the following two columns if none will be found, return empty string.

This rule will be applied only if column has the '||' operator.