### PR TITLE
Importing json-csv-core w/ sourcemap. Disabling.

### DIFF
--- a/packages/json-csv-core/tsconfig.json
+++ b/packages/json-csv-core/tsconfig.json
@@ -3,8 +3,6 @@
 	"extends": "../../tsconfig-base.json",
 	"compilerOptions": {
 		"allowSyntheticDefaultImports": true,
-		"inlineSourceMap": true,
-		"sourceMap": false,
 		"lib": ["dom", "dom.iterable", "esnext"],
 		"module": "Node16",
 		"moduleResolution": "Node16",


### PR DESCRIPTION
Disabling source maps for core since it causes issues with consumers.