### PR TITLE
fixing publish workflows, bumping version to test

### DIFF
--- a/.github/workflows/push-core.yml
+++ b/.github/workflows/push-core.yml
@@ -39,7 +39,7 @@ jobs:
       node-version-file: '.nvmrc'
       scope: '@iwsio'
       install-command: npm ci
-      build-command: npm run build -w packages/json-csv-core
+      build-command: npm run build
       publish-command: npm publish -w packages/json-csv-core --access public
     secrets:
       # This token is used for reading npm packages; use when private packages are used

--- a/.github/workflows/push-node.yml
+++ b/.github/workflows/push-node.yml
@@ -39,7 +39,7 @@ jobs:
       node-version-file: '.nvmrc'
       scope: '@iwsio'
       install-command: npm ci
-      build-command: npm run build -w packages/json-csv-node
+      build-command: npm run build
       publish-command: npm publish -w packages/json-csv-node --access public
     secrets:
       # This token is used for reading npm packages; use when private packages are used

--- a/package-lock.json
+++ b/package-lock.json
@@ -5549,7 +5549,7 @@
     },
     "packages/json-csv-core": {
       "name": "@iwsio/json-csv-core",
-      "version": "1.2.1",
+      "version": "1.2.2-alpha.1",
       "license": "BSD-3-Clause",
       "devDependencies": {
         "@types/chai": "^4.3.20",
@@ -5563,7 +5563,7 @@
     },
     "packages/json-csv-node": {
       "name": "@iwsio/json-csv-node",
-      "version": "6.2.1",
+      "version": "6.2.2-alpha.1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@iwsio/json-csv-core": "^1"
@@ -5577,6 +5577,15 @@
       },
       "engines": {
         "node": ">=10.17"
+      }
+    },
+    "packages/json-csv-node/node_modules/@iwsio/json-csv-core": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@iwsio/json-csv-core/-/json-csv-core-1.2.0.tgz",
+      "integrity": "sha512-qEwlmyJ61xpAXuAzsO6aXnFduLFXLFu3NoPfU+MEOmQJt/G5mfdxKbwe4itil1NLF50NpAdnAcgXsYtMkMUQVw==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=10"
       }
     },
     "samples": {

--- a/packages/json-csv-core/package.json
+++ b/packages/json-csv-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iwsio/json-csv-core",
-  "version": "1.2.1",
+  "version": "1.2.2-alpha.1",
   "description": "Easily convert JSON to CSV. This is a core library built for browser and node to support buffered conversion to CSV.",
   "keywords": [
     "json",

--- a/packages/json-csv-node/package.json
+++ b/packages/json-csv-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iwsio/json-csv-node",
-  "version": "6.2.1",
+  "version": "6.2.2-alpha.1",
   "description": "ESM/CJS module that easily converts JSON to CSV. This package supports streaming and buffered conversion to CSV.",
   "homepage": "https://github.com/IWSLLC/json-csv",
   "author": "Nathan Bridgewater <info@iws.io>",


### PR DESCRIPTION
Both core and node use `npm run build` from root package.json for build. (It's been awhile since I've looked at it). 