### PR TITLE
forcing workflow node-version to 24 despite nvmrc set to 10

### DIFF
--- a/.github/workflows/push-json-csv.yml
+++ b/.github/workflows/push-json-csv.yml
@@ -39,7 +39,7 @@ jobs:
       registry-url: 'https://registry.npmjs.org'
       skip-node-auth: true
       cache: npm
-      node-version-file: '.nvmrc'
+      node-version: 24
       scope: '@iwsio'
       install-command: ""
       build-command: ""


### PR DESCRIPTION
Doing some research, I think OIDC does not work with older versions of npm. Forcing publish runtime to be 24